### PR TITLE
Rename "feature_map" variables to "feature_dict" to avoid overloading

### DIFF
--- a/src/tf_container/proxy_client.py
+++ b/src/tf_container/proxy_client.py
@@ -129,15 +129,15 @@ class GRPCProxyClient(object):
         request.model_spec.name = self.model_name
         request.model_spec.signature_name = self.signature_name
 
-        features_map_list = self._create_features_map_list(data)
+        feature_dict_list = self._create_feature_dict_list(data)
 
-        examples = [_create_tf_example(features_map) for features_map in features_map_list]
+        examples = [_create_tf_example(feature_dict) for feature_dict in feature_dict_list]
 
         request.input.example_list.examples.extend(examples)
 
         return request
 
-    def _create_features_map_list(self, data):
+    def _create_feature_dict_list(self, data):
         """
         Parses the input data and returns a [dict<string, iterable>] which will be used to create the tf examples.
         If the input data is not a dict, a dictionary will be created with the default predict key PREDICT_INPUTS
@@ -212,12 +212,13 @@ Valid formats: tensor_pb2.TensorProto, dict<string,  tensor_pb2.TensorProto> and
             raise ValueError(msg.format(data))
 
 
-def _create_tf_example(feature_map):
+def _create_tf_example(feature_dict):
     """
-    Creates a tf example protobuf message given a feature map. The protobuf message is defined here
+    Creates a tf example protobuf message given a feature dict. The protobuf message is defined here
         https://github.com/tensorflow/serving/blob/master/tensorflow_serving/apis/input.proto#L19
     Args:
-        feature_map: a feature maps
+        feature_dict (dict of str -> feature): feature can be any of the following:
+          int, strings, unicode object, float, or list of any of the previous types.
 
     Returns:
         a tf.train.Example including the features
@@ -244,5 +245,5 @@ def _create_tf_example(feature_map):
                                            or classification_pb2.ClassificationRequest"""
             raise ValueError(message.format(feature, type(feature)))
 
-    features = {k: _create_feature(v) for k, v in feature_map.items()}
+    features = {k: _create_feature(v) for k, v in feature_dict.items()}
     return example_pb2.Example(features=feature_pb2.Features(feature=features))


### PR DESCRIPTION
It seems "feature map" is an existing ML term which means something different (transformation between raw input data, e.g. images or text, to a vector representation).

Also updated the docstring for the feature_dict parameter to describe what types it can accept.

Unit tests pass.