### PR TITLE
Modify integration tests to run nvidia-docker for gpu

### DIFF
--- a/test/integ/conftest.py
+++ b/test/integ/conftest.py
@@ -21,9 +21,10 @@ SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 
 def pytest_addoption(parser):
     parser.addoption('--docker-base-name', default='preprod-tensorflow')
-    parser.addoption('--tag')
+    parser.addoption('--tag', required=True)
     parser.addoption('--region', default='us-west-2')
-    parser.addoption('--tf-version')
+    parser.addoption('--framework-version', required=True)
+    parser.addoption('--processor', required=True, choices=['gpu','cpu'])
 
 
 @pytest.fixture(scope='session')
@@ -37,13 +38,18 @@ def tag(request):
 
 
 @pytest.fixture(scope='session')
+def processor(request):
+    return request.config.getoption('--processor')
+
+
+@pytest.fixture(scope='session')
 def region(request):
     return request.config.getoption('--region')
 
 
 @pytest.fixture(scope='session')
-def tf_version(request):
-    return request.config.getoption('--tf-version')
+def framework_version(request):
+    return request.config.getoption('--framework-version')
 
 
 @pytest.fixture(scope='session')

--- a/test/integ/test_layers_prediction.py
+++ b/test/integ/test_layers_prediction.py
@@ -7,7 +7,7 @@ from test.integ.docker_utils import train, HostingContainer
 from test.integ.utils import create_config_files, copy_resource, file_exists
 
 
-def test_layers_prediction(docker_image, sagemaker_session, opt_ml):
+def test_layers_prediction(docker_image, sagemaker_session, opt_ml, processor):
     resource_path = os.path.join(SCRIPT_PATH, '../resources/mnist')
 
     copy_resource(resource_path, opt_ml, 'code')
@@ -23,7 +23,7 @@ def test_layers_prediction(docker_image, sagemaker_session, opt_ml):
                         dict(training_steps=1, evaluation_steps=1))
     os.makedirs(os.path.join(opt_ml, 'model'))
 
-    train(docker_image, opt_ml)
+    train(docker_image, opt_ml, processor)
 
     assert file_exists(opt_ml, 'model/export/Servo'), 'model was not exported'
     assert file_exists(opt_ml, 'model/checkpoint'), 'checkpoint was not created'
@@ -31,5 +31,5 @@ def test_layers_prediction(docker_image, sagemaker_session, opt_ml):
     assert not file_exists(opt_ml, 'output/failure'), 'Failure happened'
 
     with HostingContainer(image=docker_image, opt_ml=opt_ml,
-                          script_name='mnist.py') as c:
+                          script_name='mnist.py', processor=processor) as c:
         c.execute_pytest('test/integ/container_tests/layers_prediction.py')

--- a/test/integ/test_s3_checkpoint_save_timeout.py
+++ b/test/integ/test_s3_checkpoint_save_timeout.py
@@ -9,7 +9,7 @@ from test.integ.conftest import SCRIPT_PATH
 
 
 # https://github.com/tensorflow/tensorflow/issues/15868
-def test_s3_checkpoint_save_timeout(docker_image, opt_ml, sagemaker_session):
+def test_s3_checkpoint_save_timeout(docker_image, opt_ml, sagemaker_session, processor):
     resource_path = os.path.join(SCRIPT_PATH, '../resources/python_sdk')
 
     default_bucket = sagemaker_session.default_bucket()
@@ -29,7 +29,7 @@ def test_s3_checkpoint_save_timeout(docker_image, opt_ml, sagemaker_session):
     )
     create_config_files('rand_model_emb.py', s3_source_archive.s3_prefix, opt_ml, hyperparameters)
 
-    train(docker_image, opt_ml)
+    train(docker_image, opt_ml, processor)
 
     assert file_exists(opt_ml, 'output/success'), 'Success file was not created'
     assert not file_exists(opt_ml, 'output/failure'), 'Failure happened'

--- a/test/integ/test_versions.py
+++ b/test/integ/test_versions.py
@@ -3,12 +3,12 @@ from test.integ.docker_utils import Container
 
 
 @pytest.fixture
-def required_versions(tf_version):
-    if tf_version == '1.4.1':
+def required_versions(framework_version):
+    if framework_version == '1.4.1':
         return ['tensorflow-serving-api==1.4.0',
                 'tensorflow-tensorboard==0.4.0',
                 'tensorflow==1.4.1']
-    elif tf_version == '1.5.0':
+    elif framework_version == '1.5.0':
         return ['tensorflow-serving-api==1.5.0',
                 'tensorflow-tensorboard==1.5.1',
                 'tensorflow==1.5.0']
@@ -16,8 +16,8 @@ def required_versions(tf_version):
         raise ValueError("invalid internal test config")
 
 
-def test_framework_versions(docker_image, required_versions):
-    with Container(docker_image) as c:
+def test_framework_versions(docker_image, processor, required_versions):
+    with Container(docker_image, processor) as c:
         output = c.execute_command(['pip', 'freeze'])
         lines = output.splitlines()
         result = sorted([v for v in lines if v in required_versions])

--- a/test/integ/test_wide_deep_prediction.py
+++ b/test/integ/test_wide_deep_prediction.py
@@ -7,7 +7,7 @@ from test.integ.conftest import SCRIPT_PATH
 from test.integ.docker_utils import HostingContainer, train
 
 
-def test_wide_deep(docker_image, sagemaker_session, opt_ml):
+def test_wide_deep(docker_image, sagemaker_session, opt_ml, processor):
     resource_path = os.path.join(SCRIPT_PATH, '../resources/wide_deep')
 
     copy_resource(resource_path, opt_ml, 'code')
@@ -24,12 +24,13 @@ def test_wide_deep(docker_image, sagemaker_session, opt_ml):
 
     os.makedirs(os.path.join(opt_ml, 'model'))
 
-    train(docker_image, opt_ml)
+    train(docker_image, opt_ml, processor)
 
     assert file_exists(opt_ml, 'model/export/Servo'), 'model was not exported'
     assert file_exists(opt_ml, 'model/checkpoint'), 'checkpoint was not created'
     assert file_exists(opt_ml, 'output/success'), 'Success file was not created'
     assert not file_exists(opt_ml, 'output/failure'), 'Failure happened'
 
-    with HostingContainer(image=docker_image, opt_ml=opt_ml, script_name='wide_deep.py') as c:
+    with HostingContainer(image=docker_image, opt_ml=opt_ml, script_name='wide_deep.py',
+                          processor=processor) as c:
         c.execute_pytest('test/integ/container_tests/wide_deep_prediction.py')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Run nvidia-docker for tests for gpu.

Integ & unit tests pass. Assumes that nvidia-docker is installed for gpu tests.

pytest test/unit
pytest test/integ/ --docker-base-name  --tag 1.4.1-gpu-py2 --processor gpu --framework-version 1.4.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.