### PR TITLE
Fix typo in path for integ test

### DIFF
--- a/test/integ/test_train_input_fn_with_input_channels.py
+++ b/test/integ/test_train_input_fn_with_input_channels.py
@@ -8,7 +8,7 @@ from test.integ.conftest import SCRIPT_PATH
 
 
 def test_train_input_fn_with_input_channels(docker_image, sagemaker_session, opt_ml, processor):
-    resource_path = os.path.join(SCRIPT_PATH, 'resources/iris')
+    resource_path = os.path.join(SCRIPT_PATH, '../resources/iris')
 
     copy_resource(resource_path, opt_ml, 'code')
     copy_resource(resource_path, opt_ml, 'data', 'input/data')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change fixes a typo that was causing the integ test to fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
