### PR TITLE
Fix file path for integ test

### DIFF
--- a/test/integ/test_train_input_fn_with_input_channels.py
+++ b/test/integ/test_train_input_fn_with_input_channels.py
@@ -33,4 +33,4 @@ def test_train_input_fn_with_input_channels(docker_image, sagemaker_session, opt
 
     with HostingContainer(image=docker_image, opt_ml=opt_ml,
                           script_name='iris_train_input_fn_with_channels.py', processor=processor) as c:
-        c.execute_pytest('integration-test/container_tests/estimator_classification.py')
+        c.execute_pytest('test/integ/container_tests/estimator_classification.py')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Path to integ test within hosting container was wrong.

All tests ran successfully.

pytest test/integ/ --tag 1.4.1-cpu-py2 --framework-version 1.4.1 --processor cpu --docker-base-name preprod-tensorflow

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
