### PR TITLE
Use wget to install tensorflow-model-server

### DIFF
--- a/docker/1.5.0/final/py2/Dockerfile.cpu
+++ b/docker/1.5.0/final/py2/Dockerfile.cpu
@@ -6,19 +6,16 @@ WORKDIR /root
 
 RUN apt-get -y update && \
     apt-get -y install curl && \
+    apt-get -y install wget && \
     apt-get -y install vim && \
     apt-get -y install iputils-ping && \
     apt-get -y install nginx
 
 RUN pip install numpy boto3 six awscli flask==0.11 Jinja2==2.9 tensorflow-serving-api==1.5 gevent gunicorn
 
-# install tensorflow-model-server
-RUN echo "deb [arch=amd64] http://storage.googleapis.com/tensorflow-serving-apt stable tensorflow-model-server \
-    tensorflow-model-server-universal" |  tee /etc/apt/sources.list.d/tensorflow-serving.list && \
-    curl https://storage.googleapis.com/tensorflow-serving-apt/tensorflow-serving.release.pub.gpg | apt-key add - && \
-    apt-get update && \
-    apt-get install tensorflow-model-server=1.5.0
-
+# install tensorflow-model-server 1.5.
+RUN wget 'http://storage.googleapis.com/tensorflow-serving-apt/pool/tensorflow-model-server/t/tensorflow-model-server/tensorflow-model-server_1.5.0_all.deb' && \
+    dpkg -i tensorflow-model-server_1.5.0_all.deb
 
 # install telegraf
 RUN cd /tmp && \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use wget to install tensorflow-model-server 1.5, as apt only has access to the latest, which is 1.6.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
