### PR TITLE
fix dl_container not found

### DIFF
--- a/docker/1.15.0/py2/Dockerfile.cpu
+++ b/docker/1.15.0/py2/Dockerfile.cpu
@@ -114,7 +114,8 @@ RUN pip install --no-cache-dir -U \
     horovod==0.18.2
 
 COPY dockerd-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
-COPY deep_learning_container.py /usr/local/bin/deep_learning_container.py
+
+ADD https://raw.githubusercontent.com/aws/aws-deep-learning-containers-utils/master/deep_learning_container.py /usr/local/bin/deep_learning_container.py
 
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.py \
  && chmod +x /usr/local/bin/deep_learning_container.py

--- a/docker/1.15.0/py2/Dockerfile.gpu
+++ b/docker/1.15.0/py2/Dockerfile.gpu
@@ -156,7 +156,8 @@ RUN cat /etc/ssh/ssh_config | grep -v StrictHostKeyChecking > /etc/ssh/ssh_confi
  && mv /etc/ssh/ssh_config.new /etc/ssh/ssh_config
 
 COPY dockerd-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
-COPY deep_learning_container.py /usr/local/bin/deep_learning_container.py
+
+ADD https://raw.githubusercontent.com/aws/aws-deep-learning-containers-utils/master/deep_learning_container.py /usr/local/bin/deep_learning_container.py
 
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.py \
  && chmod +x /usr/local/bin/deep_learning_container.py

--- a/docker/1.15.0/py3/Dockerfile.cpu
+++ b/docker/1.15.0/py3/Dockerfile.cpu
@@ -116,7 +116,8 @@ RUN pip install --no-cache-dir -U \
  && rm -f $FRAMEWORK_SUPPORT_INSTALLABLE
 
 COPY dockerd-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
-COPY deep_learning_container.py /usr/local/bin/deep_learning_container.py
+
+ADD https://raw.githubusercontent.com/aws/aws-deep-learning-containers-utils/master/deep_learning_container.py /usr/local/bin/deep_learning_container.py
 
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.py \
  && chmod +x /usr/local/bin/deep_learning_container.py

--- a/docker/1.15.0/py3/Dockerfile.gpu
+++ b/docker/1.15.0/py3/Dockerfile.gpu
@@ -162,7 +162,8 @@ RUN cat /etc/ssh/ssh_config | grep -v StrictHostKeyChecking > /etc/ssh/ssh_confi
  && mv /etc/ssh/ssh_config.new /etc/ssh/ssh_config
 
 COPY dockerd-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
-COPY deep_learning_container.py /usr/local/bin/deep_learning_container.py
+
+ADD https://raw.githubusercontent.com/aws/aws-deep-learning-containers-utils/master/deep_learning_container.py /usr/local/bin/deep_learning_container.py
 
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.py \
  && chmod +x /usr/local/bin/deep_learning_container.py


### PR DESCRIPTION
*Description of changes:*
When trying to build 1.15.0 tf docker image using the command
```
docker build -t preprod-tensorflow:1.15.0-gpu-py3 --build-arg py_version=3 --build-arg framework_installable=tensorflow_gpu-1.15.0-cp36-cp36m-manylinux2010_x86_64.whl -f Dockerfile.gpu .
```
It failed with
```
COPY failed: stat /var/lib/docker/tmp/docker-builder800355994/deep_learning_container.py: no such file or directory
```
This was because the deep_learning_container.py isn't pulled from remote.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
