### PR TITLE
fix: add condition to avoid error when 'model_dir' is None

### DIFF
--- a/src/sagemaker_tensorflow_container/training.py
+++ b/src/sagemaker_tensorflow_container/training.py
@@ -204,7 +204,7 @@ def _log_model_missing_warning(model_dir):
 
 
 def _model_dir_with_training_job(model_dir, job_name):
-    if model_dir.startswith("/opt/ml"):
+    if model_dir and model_dir.startswith("/opt/ml"):
         return model_dir
     else:
         return "{}/{}/model".format(model_dir, job_name)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/sagemaker-python-sdk/pull/1954

*Description of changes:*
Check `model_dir` is not None or False before checking its content.
When `TensorFlow.model_dir` is set to False, the current logic will raise error.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
