### PR TITLE
add condition to avoid error when 'model_dir' is None

### DIFF
--- a/src/sagemaker_tensorflow_container/training.py
+++ b/src/sagemaker_tensorflow_container/training.py
@@ -204,7 +204,7 @@ def _log_model_missing_warning(model_dir):
 
 
 def _model_dir_with_training_job(model_dir, job_name):
-    if model_dir.startswith("/opt/ml"):
+    if model_dir and model_dir.startswith("/opt/ml"):
         return model_dir
     else:
         return "{}/{}/model".format(model_dir, job_name)


### PR DESCRIPTION
*Issue #, if available:*
Tuning job failed with RL container with error trace:
```
AlgorithmError: framework error: 
Traceback (most recent call last): 
File \"/usr/local/lib/python3.6/dist-packages/sagemaker_containers/_trainer.py\", line 84, in train\n  entrypoint()\n File \"/usr/local/lib/python3.6/dist-packages/sagemaker_tensorflow_container/training.py\", line 206, in main
model_dir = _model_dir_with_training_job(hyperparameters.get('model_dir'), env.job_name)
File \"/usr/local/lib/python3.6/dist-packages/sagemaker_tensorflow_container/training.py\", line 189, in _model_dir_with_training_job\n  if model_dir.startswith('/opt/ml'):
AttributeError: 'NoneType' object has no attribute 'startswith'\n\n'NoneType' object has no attribute 'startswith'
```
*Description of changes:*
Add a condition to avoid the above error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
