### PR TITLE
fix: workaround to print stderr when capture_error is True

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     install_requires=[
-        "sagemaker-training>=3.6.3",
+        "sagemaker-training>=3.6.4",
         "numpy",
         "scipy",
         "sklearn",


### PR DESCRIPTION
*Description of changes:*
Consume the workaround from https://github.com/aws/sagemaker-training-toolkit/pull/86

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
