### PR TITLE
fix: Update deprecated dependency package name from sklearn to scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
         "sagemaker-training>=4.1.3",
         "numpy",
         "scipy",
-        "sklearn",
+        "scikit-learn",
         "pandas",
         "Pillow",
         "h5py",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read_version():
 
 
 test_dependencies = [
-    "tox",
+    "tox==3.13.1",
     "flake8",
     "pytest",
     "pytest-cov",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read_version():
 
 
 test_dependencies = [
-    "tox==3.13.1",
+    "tox",
     "flake8",
     "pytest",
     "pytest-cov",

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ deps =
     flake8
     flake8-future-import
     flake8-import-order
-commands = flake8
+commands = flake8 --append-config .flake8
 
 
 [testenv:twine]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changing the sklearn dep to scikit-learn following the advisory published at https://github.com/scikit-learn/sklearn-pypi-package.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
